### PR TITLE
Fix for SchnorrSignature::verify() method.

### DIFF
--- a/src/Crypto/Signature/SchnorrSignature.php
+++ b/src/Crypto/Signature/SchnorrSignature.php
@@ -118,9 +118,10 @@ class SchnorrSignature
         $tagChallengeSingle = hash('sha256', self::CHALLENGE);
         $tagChallenge       = $tagChallengeSingle . $tagChallengeSingle;
         $paddedR            = str_pad(gmp_strval($r, 16), 64, '0', STR_PAD_LEFT);
+        $paddedX            = str_pad(gmp_strval($P->getX(), 16), 64, '0', STR_PAD_LEFT);
 
         // convert the hex to binary so it is NOT hashed as a simple string
-        $concatToHash = hex2bin($tagChallenge . $paddedR . gmp_strval($P->getX(), 16) . $m);
+        $concatToHash = hex2bin($tagChallenge . $paddedR . $paddedX . $m);
         $schnorrVal   = hash('sha256', $concatToHash);
 
         $e = gmp_mod(gmp_init($schnorrVal, 16), gmp_init(JacobianPoint::CurveN, 16));


### PR DESCRIPTION
Turns out `$P->getX()` is not necessarily 32 bytes long exactly.

We stumbled upon [a particular combination](https://github.com/swentel/nostr-php/issues/49#issuecomment-1963976656) of valid public key, message and signature where `gmp_strval($P->getX(), 16)` returns a 63 character hex string, which breaks the subsequent calls to hex2bin() and hash().

The obvious fix seems to be to pad the hex string with left zeroes, like is already being done for `$r`.


Please, consider tagging a new release including this bugfix.